### PR TITLE
Add XFS metadata: blocks per file and block size 

### DIFF
--- a/dissect/xfs/xfs.py
+++ b/dissect/xfs/xfs.py
@@ -295,6 +295,10 @@ class INode:
         return self.inode.di_size
 
     @property
+    def number_of_blocks(self) -> int:
+        return self.inode.di_nblocks
+
+    @property
     def data_extents(self) -> int:
         if self._has_large_extent_counts():
             return self.inode.di_big_nextents

--- a/dissect/xfs/xfs.py
+++ b/dissect/xfs/xfs.py
@@ -295,7 +295,7 @@ class INode:
         return self.inode.di_size
 
     @property
-    def number_of_blocks(self) -> int:
+    def nblocks(self) -> int:
         return self.inode.di_nblocks
 
     @property

--- a/tests/test_xfs.py
+++ b/tests/test_xfs.py
@@ -23,11 +23,11 @@ def test_xfs(xfs_bin):
     assert list(root.listdir().keys()) == [".", "..", "test_file", "test_dir", "test_link"]
 
     test_file = xfs.get("test_file")
-    assert test_file.number_of_blocks == 1
+    assert test_file.nblocks == 1
     assert test_file.open().read() == b"test content\n"
 
     test_link = xfs.get("test_link")
-    assert test_link.number_of_blocks == 0
+    assert test_link.nblocks == 0
     assert test_link.filetype == stat.S_IFLNK
     assert test_link.link == "test_dir/test_file"
 
@@ -37,22 +37,22 @@ def test_xfs_sparse(xfs_sparse_bin):
 
     sparse_start = xfs.get("sparse_start")
     assert sparse_start.size == 0x258000
-    assert sparse_start.number_of_blocks == 200
+    assert sparse_start.nblocks == 200
     assert sparse_start.dataruns() == [(None, 400), (1392, 200)]
 
     sparse_hole = xfs.get("sparse_hole")
     assert sparse_hole.size == 0x258000
-    assert sparse_hole.number_of_blocks == 400
+    assert sparse_hole.nblocks == 400
     assert sparse_hole.dataruns() == [(1792, 200), (None, 200), (2192, 200)]
 
     sparse_end = xfs.get("sparse_end")
     assert sparse_end.size == 0x190000
-    assert sparse_end.number_of_blocks == 200
+    assert sparse_end.nblocks == 200
     assert sparse_end.dataruns() == [(2392, 200), (None, 200)]
 
     sparse_all = xfs.get("sparse_all")
     assert sparse_all.size == 0x500000
-    assert sparse_all.number_of_blocks == 0
+    assert sparse_all.nblocks == 0
     assert sparse_all.dataruns() == [(None, 1280)]
 
 

--- a/tests/test_xfs.py
+++ b/tests/test_xfs.py
@@ -11,6 +11,7 @@ def test_xfs(xfs_bin):
     xfs = XFS(xfs_bin)
 
     assert xfs.version == 5
+    assert xfs.block_size == 4096
     assert str(xfs.uuid) == "3fb8342e-e144-4f0c-8bd7-725e78966200"
     assert str(xfs.meta_uuid) == "00000000-0000-0000-0000-000000000000"
 
@@ -22,6 +23,7 @@ def test_xfs(xfs_bin):
     assert list(root.listdir().keys()) == [".", "..", "test_file", "test_dir", "test_link"]
 
     test_file = xfs.get("test_file")
+    assert test_file.number_of_blocks == 1
     assert test_file.open().read() == b"test content\n"
 
     test_link = xfs.get("test_link")

--- a/tests/test_xfs.py
+++ b/tests/test_xfs.py
@@ -27,6 +27,7 @@ def test_xfs(xfs_bin):
     assert test_file.open().read() == b"test content\n"
 
     test_link = xfs.get("test_link")
+    assert test_link.number_of_blocks == 0
     assert test_link.filetype == stat.S_IFLNK
     assert test_link.link == "test_dir/test_file"
 
@@ -36,18 +37,22 @@ def test_xfs_sparse(xfs_sparse_bin):
 
     sparse_start = xfs.get("sparse_start")
     assert sparse_start.size == 0x258000
+    assert sparse_start.number_of_blocks == 200
     assert sparse_start.dataruns() == [(None, 400), (1392, 200)]
 
     sparse_hole = xfs.get("sparse_hole")
     assert sparse_hole.size == 0x258000
+    assert sparse_hole.number_of_blocks == 400
     assert sparse_hole.dataruns() == [(1792, 200), (None, 200), (2192, 200)]
 
     sparse_end = xfs.get("sparse_end")
     assert sparse_end.size == 0x190000
+    assert sparse_end.number_of_blocks == 200
     assert sparse_end.dataruns() == [(2392, 200), (None, 200)]
 
     sparse_all = xfs.get("sparse_all")
     assert sparse_all.size == 0x500000
+    assert sparse_all.number_of_blocks == 0
     assert sparse_all.dataruns() == [(None, 1280)]
 
 


### PR DESCRIPTION
Expose blocks per file and the block size of the file system

Companion PR to https://github.com/fox-it/dissect.target/pull/874

Closes #32 