### PR TITLE
Fix support for long non-residential symlinks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@ tests/data/xfs_symlink_test3.bin.gz filter=lfs diff=lfs merge=lfs -text
 tests/data/xfs_bigtime.bin.gz filter=lfs diff=lfs merge=lfs -text
 tests/data/xfs.bin.gz filter=lfs diff=lfs merge=lfs -text
 tests/data/xfs_sparse.bin.gz filter=lfs diff=lfs merge=lfs -text
+tests/data/xfs_symlink_long.bin.gz filter=lfs diff=lfs merge=lfs -text

--- a/dissect/xfs/xfs.py
+++ b/dissect/xfs/xfs.py
@@ -6,7 +6,7 @@ import os
 import stat
 from datetime import datetime
 from functools import lru_cache
-from typing import BinaryIO, Iterator, Optional, Union
+from typing import BinaryIO, Iterator
 from uuid import UUID
 
 from dissect.util import ts
@@ -55,7 +55,7 @@ class XFS:
 
         self.root = self.get_inode(self.sb.sb_rootino)
 
-    def get(self, path: Union[int, str], node: Optional[INode] = None) -> INode:
+    def get(self, path: int | str, node: INode | None = None) -> INode:
         if isinstance(path, int):
             return self.get_inode(path)
 
@@ -102,14 +102,14 @@ class XFS:
         for record in self.walk_large_tree(block, 16, (c_xfs.XFS_BMAP_MAGIC, c_xfs.XFS_BMAP_CRC_MAGIC)):
             yield parse_fsblock(record)
 
-    def walk_large_tree(self, block: int, leaf_size: int, magic: Optional[list[int]] = None) -> Iterator[bytes]:
+    def walk_large_tree(self, block: int, leaf_size: int, magic: list[int] | None = None) -> Iterator[bytes]:
         self.fh.seek(block * self.block_size)
         root = self._lblock_s(self.fh)
 
         yield from self._walk_large_tree(root, leaf_size, magic)
 
     def walk_small_tree(
-        self, block: int, agnum: int, leaf_size: int, magic: Optional[list[int]] = None
+        self, block: int, agnum: int, leaf_size: int, magic: list[int] | None = None
     ) -> Iterator[bytes]:
         block = agnum * self.sb.sb_agblocks + block
         self.fh.seek(block * self.block_size)
@@ -122,7 +122,7 @@ class XFS:
         node: c_xfs.xfs_btree_sblock | c_xfs.xfs_btree_sblock_crc,
         leaf_size: int,
         agnum: int,
-        magic: Optional[list[int]] = None,
+        magic: list[int] | None = None,
     ) -> Iterator[bytes]:
         fh = self.fh
         if magic and node.bb_magic not in magic:
@@ -148,7 +148,7 @@ class XFS:
         self,
         node: c_xfs.xfs_btree_lblock | c_xfs.xfs_btree_lblock_crc,
         leaf_size: int,
-        magic: Optional[list[int]] = None,
+        magic: list[int] | None = None,
     ) -> Iterator[bytes]:
         fh = self.fh
         if magic and node.bb_magic not in magic:
@@ -210,9 +210,9 @@ class AllocationGroup:
     def get_inode(
         self,
         inum: int,
-        filename: Optional[str] = None,
-        filetype: Optional[int] = None,
-        parent: Optional[INode] = None,
+        filename: str | None = None,
+        filetype: int | None = None,
+        parent: INode | None = None,
         lazy: bool = False,
     ) -> INode:
         inode = INode(self, inum, filename, filetype, parent=parent)
@@ -230,7 +230,7 @@ class AllocationGroup:
     def walk_agi(self) -> Iterator[c_xfs.xfs_inobt_rec]:
         yield from self.xfs.walk_agi(self.agi.agi_root, self.num)
 
-    def walk_tree(self, fsb: int, magic: Optional[list[int]] = None, small: bool = False):
+    def walk_tree(self, fsb: int, magic: list[int] | None = None, small: bool = False):
         agnum, blknum = fsb_to_bb(fsb, self.sb.sb_agblklog)
         block = agnum * self.xfs.sb.sb_agblocks + blknum
 
@@ -245,9 +245,9 @@ class INode:
         self,
         ag: AllocationGroup,
         inum: int,
-        filename: Optional[str] = None,
-        filetype: Optional[int] = None,
-        parent: Optional[INode] = None,
+        filename: str | None = None,
+        filetype: int | None = None,
+        parent: INode | None = None,
     ):
         self.ag = ag
         self.xfs = ag.xfs
@@ -517,7 +517,7 @@ class INode:
 
         return RangeStream(self._buf, offset, size)
 
-    def dataruns(self) -> list[tuple[Optional[int], int]]:
+    def dataruns(self) -> list[tuple[int | None, int]]:
         if not self._runlist:
             runs = []
             run_offset = 0

--- a/dissect/xfs/xfs.py
+++ b/dissect/xfs/xfs.py
@@ -329,6 +329,7 @@ class INode:
                 # need three blocks. These three blocks could theoretially be distributed over multiple extents.
                 # Linux kernel handles this by using sl_offset to piece the symlink back together.
                 # As this edge case of an edge case is very unlikely, it is unsupported until we observe it.
+                # Ticket: https://github.com/fox-it/dissect.xfs/issues/36
                 if len(self.dataruns()) > 1:
                     raise NotImplementedError(f"{self!r} has a symlink distributed over multiple extents")
 

--- a/dissect/xfs/xfs.py
+++ b/dissect/xfs/xfs.py
@@ -325,7 +325,10 @@ class INode:
 
         if not self._link:
             if self.inode.di_format != c_xfs.xfs_dinode_fmt.XFS_DINODE_FMT_LOCAL and self.xfs.version == 5:
-                fh = self.open()
+                # We do not use open because for non-resident symlinks self.size does not include the symlink header
+                runs = self.dataruns()
+                symlink_size = c_xfs.xfs_dsymlink_hdr.size + self.size
+                fh = RunlistStream(self.xfs.fh, runs, symlink_size, self.xfs.block_size)
 
                 header = c_xfs.xfs_dsymlink_hdr(fh)
                 if header.sl_magic != c_xfs.XFS_SYMLINK_MAGIC:

--- a/tests/data/.gitattributes
+++ b/tests/data/.gitattributes
@@ -1,1 +1,0 @@
-xfs_symlink_long.bin.gz filter=lfs diff=lfs merge=lfs -text

--- a/tests/data/.gitattributes
+++ b/tests/data/.gitattributes
@@ -1,0 +1,1 @@
+xfs_symlink_long.bin.gz filter=lfs diff=lfs merge=lfs -text

--- a/tests/data/xfs_symlink_long.bin.gz
+++ b/tests/data/xfs_symlink_long.bin.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ff94bd598afb51a98eb02295d584cfc34a59dd5fde6f7161bf32c5ef1ac20b3e
+size 50458

--- a/tests/test_xfs.py
+++ b/tests/test_xfs.py
@@ -73,6 +73,7 @@ def test_xfs_bigtime(xfs_bigtime_bin):
         ("tests/data/xfs_symlink_test1.bin.gz"),
         ("tests/data/xfs_symlink_test2.bin.gz"),
         ("tests/data/xfs_symlink_test3.bin.gz"),
+        ("tests/data/xfs_symlink_long.bin.gz"),
     ],
 )
 def test_symlinks(image_file):
@@ -85,4 +86,6 @@ def test_symlinks(image_file):
         return node
 
     with gzip.open(image_file, "rb") as disk:
-        assert resolve(XFS(disk).get(path)).open().read() == expect
+        link_inode = resolve(XFS(disk).get(path))
+        assert link_inode.nblocks == 1
+        assert link_inode.open().read() == expect


### PR DESCRIPTION
The targets of  non-residential symlinks were not completely read. This is because the size of the symlink header was not taken into account on XFS version 5. 

Added a test with a very long symlink and also check number of blocks. 

Bonus:
- Modernize typings

Closes #34 