### PR TITLE
Add stricter Ruff linting

### DIFF
--- a/dissect/xfs/__init__.py
+++ b/dissect/xfs/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dissect.xfs.exceptions import (
     Error,
     FileNotFoundError,

--- a/dissect/xfs/c_xfs.py
+++ b/dissect/xfs/c_xfs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import stat
 
 from dissect.cstruct import cstruct

--- a/dissect/xfs/exceptions.py
+++ b/dissect/xfs/exceptions.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class Error(Exception):
     pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ select = [
   "SLOT",
   "SIM",
   "TID",
-  "TCH",
+  "TC",
   "PTH",
   "PLC",
   "TRY",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,8 +102,25 @@ select = [
   "PERF",
   "FURB",
   "RUF",
+  "D"
 ]
-ignore = ["E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM105", "TRY003"]
+ignore = [
+    "E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM105", "TRY003", "PLC0415",
+    # Ignore some pydocstyle rules for now as they require a larger cleanup
+    "D1",
+    "D205",
+    "D301",
+    "D417",
+    # Seems bugged: https://github.com/astral-sh/ruff/issues/16824
+    "D402",
+]
+future-annotations = true
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.ruff.lint.flake8-type-checking]
+strict = true
 
 [tool.ruff.lint.per-file-ignores]
 "tests/_docs/**" = ["INP001"]
@@ -111,6 +128,7 @@ ignore = ["E203", "B904", "UP024", "ANN002", "ANN003", "ANN204", "ANN401", "SIM1
 [tool.ruff.lint.isort]
 known-first-party = ["dissect.xfs"]
 known-third-party = ["dissect"]
+required-imports = ["from __future__ import annotations"]
 
 [tool.setuptools.packages.find]
 include = ["dissect.*"]

--- a/tests/_docs/conf.py
+++ b/tests/_docs/conf.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 extensions = [
     "autoapi.extension",
     "sphinx.ext.autodoc",


### PR DESCRIPTION
Add stricter rules (doctstyle) + Add annotations import to ruff isort required imports.

Code change are only related to addition of from __future__ import annotations
Regarding few change, I suggest to not add this commit to git blame ignore file.

* fixes #52 